### PR TITLE
Treat bsb errors as warnings

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,9 +19,9 @@ const runBsb = callback => {
   execFile(bsb, ['-make-world'], callback)
 }
 
-const getCompiledFile = (path, callback) => {
+const getCompiledFile = (path, callback, emitWarning) => {
   runBsb((err, res) => {
-    if (err) return callback(err, res)
+    if (err) emitWarning(res)
 
     readFile(path, (err, res) => {
       if (err) {
@@ -49,5 +49,5 @@ module.exports = function () {
     } else {
       callback(null, res)
     }
-  })
+  }, this.emitWarning)
 }


### PR DESCRIPTION
To fix this issue: https://github.com/cxa/reason-react-webpack-starter-kit/issues/1