### PR TITLE
Transform `require`s that started with double dots

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ const getJsFile = (moduleDir, resourcePath) => {
 }
 
 const transformSrc = src =>
-  src.replace(/(require\("\.\/.*)(\.js)("\);)/g, '$1$3')
+  src.replace(/(require\("\.\.?\/.*)(\.js)("\);)/g, '$1$3')
 
 const runBsb = callback => {
   execFile(bsb, ['-make-world'], callback)


### PR DESCRIPTION
Not only `require("./module")` but `require("../src/submodule")` is also required to be transformed.