### PR TITLE
Avoid interrupting by `Error: stdout maxBuffer exceeded`

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ const transformSrc = (moduleDir, src) =>
   src.replace(/(require\("\.\.?\/.*)(\.js)("\);)/g, '$1$3')
 
 const runBsb = callback => {
-  execFile(bsb, ['-make-world'], callback)
+  execFile(bsb, ['-make-world'], { maxBuffer: Infinity }, callback)
 }
 
 const getCompiledFile = (moduleDir, path, callback) => {


### PR DESCRIPTION
<img width="1130" alt="screen shot 2017-06-12 at 11 39 38" src="https://user-images.githubusercontent.com/32127/27018543-f6ae834a-4f63-11e7-8be2-c14e8ce57ba7.png">

The`(Emitted value instead of an instance of Error)` is `Error: stdout maxBuffer exceeded`.