### PR TITLE
New config + examples without reason-js and rehydrate

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,7 @@ Create a `bsconfig.json` for Bucklescript:
     "src"
   ],
   "bs-dependencies": [
-    "reason-js",
-    "rehydrate"
+    "reason-react"
   ],
   "reason": {
     "react-jsx": true
@@ -39,7 +38,7 @@ Create a `bsconfig.json` for Bucklescript:
 }
 ```
 
-We will also need `reason-js`, `reason-react`, and `bs-platform`. Your `package.json` should look something like this:
+We will also need `reason-react`, and `bs-platform`. Your `package.json` should look something like this:
 
 ```json
 /* package.json */
@@ -56,7 +55,6 @@ We will also need `reason-js`, `reason-react`, and `bs-platform`. Your `package.
   "devDependencies": {
     "bs-loader": "^1.0.0",
     "bs-platform": "^1.5.0",
-    "reason-js": "0.0.16",
     "reason-react": "0.1.3",
     "webpack": "^2.2.1"
   },

--- a/examples/commonjs/bsconfig.json
+++ b/examples/commonjs/bsconfig.json
@@ -4,7 +4,6 @@
     "src"
   ],
   "bs-dependencies": [
-    "reason-js",
     "reason-react",
     "bs-jest"
   ],

--- a/examples/commonjs/package.json
+++ b/examples/commonjs/package.json
@@ -12,10 +12,9 @@
   "devDependencies": {
     "bs-jest": "^0.1.0",
     "bs-loader": "^1.5.0",
-    "bs-platform": "^1.7.1",
+    "bs-platform": "^1.7.5",
     "jest": "^20.0.4",
-    "reason-js": "0.0.16",
-    "reason-react": "^0.1.1",
+    "reason-react": "^0.1.4",
     "webpack": "^2.2.1",
     "webpack-dev-server": "^2.4.5"
   },

--- a/examples/es6/bsconfig.json
+++ b/examples/es6/bsconfig.json
@@ -4,7 +4,6 @@
     "src"
   ],
   "bs-dependencies": [
-    "reason-js",
     "reason-react"
   ],
   "reason": {

--- a/examples/es6/package.json
+++ b/examples/es6/package.json
@@ -10,10 +10,9 @@
   "license": "ISC",
   "devDependencies": {
     "bs-loader": "^1.2.1",
-    "bs-platform": "^1.7.1",
+    "bs-platform": "^1.7.5",
     "jest": "^20.0.4",
-    "reason-js": "0.0.16",
-    "reason-react": "^0.1.1",
+    "reason-react": "^0.1.4",
     "webpack": "^2.4.1",
     "webpack-dev-server": "^2.4.5"
   },


### PR DESCRIPTION
@rrdelaney reason-js is deprecated for a long time now; rehydrate is the old name of reason-react