### PR TITLE
Bump reason-react & bs-platform versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+.DS_Store
 node_modules/
 *.log

--- a/examples/commonjs/package.json
+++ b/examples/commonjs/package.json
@@ -12,9 +12,9 @@
   "devDependencies": {
     "bs-jest": "^0.1.0",
     "bs-loader": "^1.5.0",
-    "bs-platform": "^1.7.5",
+    "bs-platform": "^1.8.0",
     "jest": "^20.0.4",
-    "reason-react": "^0.1.4",
+    "reason-react": "^0.2.1",
     "webpack": "^2.2.1",
     "webpack-dev-server": "^2.4.5"
   },

--- a/examples/es6/package.json
+++ b/examples/es6/package.json
@@ -10,9 +10,9 @@
   "license": "ISC",
   "devDependencies": {
     "bs-loader": "^1.5.2",
-    "bs-platform": "^1.7.5",
+    "bs-platform": "^1.8.0",
     "jest": "^20.0.4",
-    "reason-react": "^0.1.4",
+    "reason-react": "^0.2.1",
     "webpack": "^3.0.0",
     "webpack-dev-server": "^2.5.0"
   },


### PR DESCRIPTION
Didn't change yarn.lock. I'm not on yarn yet... Maybe I should be.
ReasonReact v0.2.1 is a breaking change, but the examples don't use the API, so everything's fine.

cc @rrdelaney 