### PR TITLE
Add basic jest test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .DS_Store
 node_modules/
 *.log
+test/lib
+test/output

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: node_js
+node_js:
+  - 8
+cache:
+  directories:
+    - "node_modules"
+notifications:
+  email: false

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Bucklescript integration in Webpack",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "cd test && jest"
   },
   "repository": {
     "type": "git",
@@ -25,5 +25,10 @@
   "homepage": "https://github.com/rrdelaney/bs-loader#readme",
   "dependencies": {
     "loader-utils": "^1.1.0"
+  },
+  "devDependencies": {
+    "bs-platform": "^1.8.2",
+    "jest-cli": "^20.0.4",
+    "webpack": "^3.5.4"
   }
 }

--- a/test/.merlin
+++ b/test/.merlin
@@ -1,0 +1,8 @@
+####{BSB GENERATED: NO EDIT
+FLG -ppx /Users/jasonstaten/dev/bs-loader/node_modules/bs-platform/bin/bsppx.exe
+S /Users/jasonstaten/dev/bs-loader/node_modules/bs-platform/lib/ocaml
+B /Users/jasonstaten/dev/bs-loader/node_modules/bs-platform/lib/ocaml
+FLG -nostdlib -no-alias-deps -color always -w -40+6+7+27+32..39+44+45
+S fixtures
+B lib/bs/fixtures
+####BSB GENERATED: NO EDIT}

--- a/test/bsconfig.json
+++ b/test/bsconfig.json
@@ -1,0 +1,5 @@
+{
+  "name": "test",
+  "sources": ["fixtures"],
+  "package-specs": ["es6"]
+}

--- a/test/fixtures/add.re
+++ b/test/fixtures/add.re
@@ -1,0 +1,1 @@
+let add x y => x + y;

--- a/test/fixtures/dec.js
+++ b/test/fixtures/dec.js
@@ -1,0 +1,1 @@
+export const dec = x => x - 1;

--- a/test/fixtures/fib.ml
+++ b/test/fixtures/fib.ml
@@ -1,0 +1,9 @@
+external dec : int -> int = "dec" [@@bs.module "./dec"]
+open Add
+
+let fib n  =
+  let rec aux n a b =
+    if n = 0 then a
+    else
+      aux (dec n) b (add a b)
+  in aux n 1 1

--- a/test/fixtures/fib.mli
+++ b/test/fixtures/fib.mli
@@ -1,0 +1,1 @@
+val fib : int -> int

--- a/test/webpack.test.js
+++ b/test/webpack.test.js
@@ -1,0 +1,45 @@
+const webpack = require('webpack');
+const path = require('path');
+const fs = require('fs');
+
+const output = path.join(__dirname, 'output/webpack');
+const loader = path.join(__dirname, '../');
+
+const baseConfig = {
+  entry: path.join(__dirname, 'fixtures/fib.ml'),
+  module: {
+    rules: [
+      {
+        test: /\.(re|ml)$/,
+        use: {
+          loader,
+          options: {
+            module: 'es6',
+          },
+        },
+      },
+    ],
+  },
+  resolve: {
+    extensions: ['.re', '.ml', '.js'],
+  },
+  output: {
+    path: output,
+    libraryTarget: 'commonjs2',
+  },
+};
+
+it('runs', done => {
+  webpack(baseConfig, err => {
+    expect(err).toBeNull();
+
+    fs.readdir(output, (err, files) => {
+      expect(err).toBeNull();
+      expect(files.length).toBe(1);
+      const result = require(path.resolve(output, files[0]));
+      expect(result.fib(12)).toBe(233);
+
+      done();
+    });
+  });
+});


### PR DESCRIPTION
Added a test run of bs-loader in webpack to execute on Travis CI. It might help call out typos like #20.

See an example of the build here: https://travis-ci.org/statianzo/bs-loader/builds/264596754

To enable it, go to travis-ci.org, sign in, and flip the toggle for the reasonml-community/bs-loader repository.