### PR TITLE
set HAS_RUN_BSB after bsb is done.

### DIFF
--- a/packages/bs-loader/index.js
+++ b/packages/bs-loader/index.js
@@ -50,10 +50,10 @@ function transformSrc(moduleDir, src) {
 
 function runBsb(buildDir, compilation) {
   if (compilation.__HAS_RUN_BSB__) return Promise.resolve()
-  compilation.__HAS_RUN_BSB__ = true
 
   return new Promise((resolve, reject) => {
     exec(bsb, { maxBuffer: Infinity, cwd: buildDir }, (err, stdout, stderr) => {
+      compilation.__HAS_RUN_BSB__ = true
       if (err) {
         reject(`${stdout.toString()}\n${stderr.toString()}`)
       } else {


### PR DESCRIPTION
Before, you set `__HAS_RUN_BSB__` immediatly to true, so when you enter multiple times in `runBsb` you might resolve too soon, resulting in an error, because the compilation hasn't actually been done.