### PR TITLE
Adding support for the suffix bsconfig option

### DIFF
--- a/packages/bs-loader/index.js
+++ b/packages/bs-loader/index.js
@@ -10,7 +10,7 @@ const { compileFile, compileFileSync } = require('bsb-js')
 const outputDir = 'lib'
 const fileNameRegex = /\.(ml|re)$/
 
-function jsFilePath(buildDir, moduleDir, resourcePath, inSource) {
+function jsFilePath(buildDir, moduleDir, resourcePath, inSource, bsSuffix) {
   const mlFileName = resourcePath.replace(buildDir, '')
   const jsFileName = mlFileName.replace(fileNameRegex, '.js')
 
@@ -57,6 +57,7 @@ module.exports = function loader() {
   getBsConfigModuleOptions(buildDir)
     .then(bsconfig => {
       const moduleDir = bsconfig.moduleDir
+      const bsSuffix = bsconfig.suffix || '.js'
 
       const inSourceBuild = options.inSource || bsconfig.inSource || false
 
@@ -64,7 +65,8 @@ module.exports = function loader() {
         buildDir,
         moduleDir,
         this.resourcePath,
-        inSourceBuild
+        inSourceBuild,
+        bsSuffix
       )
 
       return compileFile(buildDir, moduleDir, compiledFilePath)
@@ -91,7 +93,13 @@ module.exports.process = function process(
   filename /*: string */
 ) {
   const moduleDir = 'js'
-  const compiledFilePath = jsFilePath(process.cwd(), moduleDir, filename, false)
+  const compiledFilePath = jsFilePath(
+    process.cwd(),
+    moduleDir,
+    filename,
+    false,
+    '.js'
+  )
 
   return compileFileSync(moduleDir, compiledFilePath)
 }

--- a/packages/bs-loader/index.js
+++ b/packages/bs-loader/index.js
@@ -21,7 +21,7 @@ function jsFilePath(buildDir, moduleDir, resourcePath, inSource, bsSuffix) {
   return path.join(buildDir, outputDir, moduleDir, jsFileName)
 }
 
-/*:: type Options = { moduleDir: BsModuleFormat | 'js', inSource: boolean } */
+/*:: type Options = { moduleDir: BsModuleFormat | 'js', inSource: boolean, suffix: string } */
 
 function getBsConfigModuleOptions(buildDir) /*: Promise<Options> */ {
   return readBsConfig(buildDir).then(bsconfig => {
@@ -40,7 +40,10 @@ function getBsConfigModuleOptions(buildDir) /*: Promise<Options> */ {
     const inSource =
       typeof moduleSpec === 'string' ? false : moduleSpec['in-source']
 
-    const options /*: Options */ = { moduleDir, inSource }
+    const bsSuffix = bsconfig.suffix
+    const suffix = typeof bsSuffix === 'string' ? bsSuffix : '.js'
+
+    const options /*: Options */ = { moduleDir, inSource, suffix }
     return options
   })
 }
@@ -57,7 +60,7 @@ module.exports = function loader() {
   getBsConfigModuleOptions(buildDir)
     .then(bsconfig => {
       const moduleDir = bsconfig.moduleDir
-      const bsSuffix = bsconfig.suffix || '.js'
+      const bsSuffix = bsconfig.suffix
 
       const inSourceBuild = options.inSource || bsconfig.inSource || false
 

--- a/packages/bs-loader/index.js
+++ b/packages/bs-loader/index.js
@@ -29,8 +29,15 @@ function getBsConfigModuleOptions(buildDir) /*: Promise<Options> */ {
       throw new Error(`bsconfig not found in ${buildDir}`)
     }
 
+    const bsSuffix = bsconfig.suffix
+    const suffix = typeof bsSuffix === 'string' ? bsSuffix : '.js'
+
     if (!bsconfig['package-specs'] || !bsconfig['package-specs'].length) {
-      const options /*: Options */ = { moduleDir: 'js', inSource: false }
+      const options /*: Options */ = {
+        moduleDir: 'js',
+        inSource: false,
+        suffix
+      }
       return options
     }
 
@@ -39,9 +46,6 @@ function getBsConfigModuleOptions(buildDir) /*: Promise<Options> */ {
       typeof moduleSpec === 'string' ? moduleSpec : moduleSpec.module
     const inSource =
       typeof moduleSpec === 'string' ? false : moduleSpec['in-source']
-
-    const bsSuffix = bsconfig.suffix
-    const suffix = typeof bsSuffix === 'string' ? bsSuffix : '.js'
 
     const options /*: Options */ = { moduleDir, inSource, suffix }
     return options

--- a/packages/read-bsconfig/index.js
+++ b/packages/read-bsconfig/index.js
@@ -51,7 +51,8 @@ export type BsConfig = {
   'use-stdlib': boolean,
   'bs-external-includes': string[],
   refmt: string,
-  'refmt-flags': string[]
+  'refmt-flags': string[],
+  suffix: string
 }
 */
 


### PR DESCRIPTION
So many things have changed since my last PR 😄 awesome job 🚀.

This adds support for the new suffix option in bsconfig which allows you to change the file names to end with `.bs.js` instead of `.js`