### PR TITLE
fix aliasing when running inside jest

### DIFF
--- a/packages/bs-loader/index.js
+++ b/packages/bs-loader/index.js
@@ -99,7 +99,7 @@ module.exports = function loader() {
 
 /*:: declare var c: WebpackLoaderThis; module.exports.call(c) */
 
-module.exports.process = function process(
+module.exports.process = function bsLoaderProcess(
   src /*: string */,
   filename /*: string */
 ) {


### PR DESCRIPTION
_I am not sure why this causes problems when running the loader through jest and not webpack but this simple fix seems to fix my issues. Following is the the commit message._

It looks like when running the loader from jest, `process.env` looks up
the env property on the `process` function instead of the global object.
This results in errors like the following:

```
 FAIL  test/jest_test.re
  ● Test suite failed to run

    TypeError: process.cwd is not a function

      at Function.process (node_modules/bs-loader/index.js:108:13)
          at Generator.next (<anonymous>)
```

I renamed the `process` function to something else to remove this name
aliasing issue.