### PR TITLE
fix(bs-loader): actually use suffix when building js file path

### DIFF
--- a/packages/bs-loader/index.js
+++ b/packages/bs-loader/index.js
@@ -12,7 +12,7 @@ const fileNameRegex = /\.(ml|re)$/
 
 function jsFilePath(buildDir, moduleDir, resourcePath, inSource, bsSuffix) {
   const mlFileName = resourcePath.replace(buildDir, '')
-  const jsFileName = mlFileName.replace(fileNameRegex, '.js')
+  const jsFileName = mlFileName.replace(fileNameRegex, bsSuffix)
 
   if (inSource) {
     return path.join(buildDir, jsFileName)


### PR DESCRIPTION
Apparently this was forgotten in #36  😅