### PR TITLE
have bsb-js check the normal npm install directory

### DIFF
--- a/packages/bsb-js/index.js
+++ b/packages/bsb-js/index.js
@@ -6,12 +6,17 @@ const { readFile, readFileSync } = require('fs')
 const utils = require('./utils')
 /*:: import type { BsModuleFormat } from 'read-bsconfig' */
 
-let bsbCommand
-try {
-  bsbCommand = require.resolve('bs-platform/bin/bsb.exe')
-} catch (e) {
-  bsbCommand = `bsb`
+let bsbCommand;
+const bsbLocations = ['.bin/bsb', 'bs-platform/bin/bsb.exe'];
+for (var i = 0; i < bsbLocations.length; ++i) {
+  try {
+    bsbCommand = require.resolve(bsbLocations[i]);
+    break;
+  } catch (e) {
+  }
 }
+bsbCommand = bsbCommand || `bsb`;
+
 
 const bsb = (() => {
   switch (utils.platform()) {

--- a/packages/bsb-js/index.js
+++ b/packages/bsb-js/index.js
@@ -7,7 +7,7 @@ const utils = require('./utils')
 /*:: import type { BsModuleFormat } from 'read-bsconfig' */
 
 let bsbCommand;
-const bsbLocations = ['.bin/bsb', 'bs-platform/bin/bsb.exe'];
+const bsbLocations = ['bs-platform/bin/bsb.exe', '.bin/bsb', '.bin/bsb.exe'];
 for (var i = 0; i < bsbLocations.length; ++i) {
   try {
     bsbCommand = require.resolve(bsbLocations[i]);


### PR DESCRIPTION
perhaps I did something incorrect in setup, but I was expecting bsb-js to use the bsb under my node_modules/.bin directory. 

This PR adds that location as a check and tries to maintain existing priority for the bs-platform/bin/bsb.exe