### PR TITLE
Make bsb-js resilient to _all_ errors

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -11,4 +11,5 @@ all=warn
 untyped-type-import=error
 
 [options]
+suppress_comment=\\(.\\|\n\\)*\\$FlowIssue
 emoji=true

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "reason-tooling",
   "private": true,
   "devDependencies": {
-    "flow-bin": "^0.57.3",
+    "flow-bin": "^0.74.0",
     "jest-cli": "^21.1.0"
   },
   "scripts": {

--- a/packages/bsb-js/utils.js
+++ b/packages/bsb-js/utils.js
@@ -10,6 +10,7 @@ const getErrorRegex = /(File [\s\S]*?:\r?\n|Fatal )[eE]rror: [\s\S]*?(?=ninja|\r
 const packageNotFoundRegex = /Package not found[\s\S]*?:?\r?\n[\s\S]*?[eE]rror:\s?[\s\S]*/g
 const getSuperErrorRegex = /We've found a bug for you![\s\S]*?(?=ninja: build stopped)/g
 const getWarningRegex = /((File [\s\S]*?Warning.+? \d+:)|Warning number \d+)[\s\S]*?(?=\[\d+\/\d+\]|$)/g
+const errorRegexes = [getSuperErrorRegex, getErrorRegex, packageNotFoundRegex]
 
 function platform() /*: 'darwin' | 'linux' | 'wsl' | null */ {
   const isWSL = () => {
@@ -34,18 +35,20 @@ function transformSrc(
   return src.replace(replacer, '$1$3')
 }
 
+// This function is only ever called if an error has been caught. We try to
+// process said error according to known formats, but we default to what we
+// got as an argument if they don't match. This way we always throw an error,
+// thus avoiding successful builds if something has gone wrong.
 function processBsbError(err /*: Error | string */) {
   if (typeof err === 'string') {
-    return (
-      err.match(getSuperErrorRegex) ||
-      err.match(getErrorRegex) ||
-      err.match(packageNotFoundRegex) ||
-      []
-    ).map(e => new Error(e))
-  } else if (err instanceof Error) {
-    return [err]
+    const errors = errorRegexes
+      .map(r => err.match(r))
+      .reduce((a, s) => a.concat(s), [])
+      .filter(x => x)
+
+    return (errors.length > 0 ? errors : [err]).map(e => new Error(e))
   } else {
-    return []
+    return [err]
   }
 }
 

--- a/packages/bsb-js/utils.js
+++ b/packages/bsb-js/utils.js
@@ -39,10 +39,11 @@ function transformSrc(
 // process said error according to known formats, but we default to what we
 // got as an argument if they don't match. This way we always throw an error,
 // thus avoiding successful builds if something has gone wrong.
-function processBsbError(err /*: Error | string */) {
+function processBsbError(err /*: Error | string */) /*: Error[] */ {
   if (typeof err === 'string') {
     const errors = errorRegexes
-      .map(r => err.match(r))
+    // $FlowIssue: err is definitely a string
+      .map((r /*: RegExp */) => err.match(r))
       .reduce((a, s) => a.concat(s), [])
       .filter(x => x)
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1263,9 +1263,9 @@ find-up@^2.0.0, find-up@^2.1.0:
   dependencies:
     locate-path "^2.0.0"
 
-flow-bin@^0.57.3:
-  version "0.57.3"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.57.3.tgz#843fb80a821b6d0c5847f7bb3f42365ffe53b27b"
+flow-bin@^0.74.0:
+  version "0.74.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.74.0.tgz#8017bb00efb37cbe8d81fbb7f464038bde06adc9"
 
 for-each@~0.3.2:
   version "0.3.2"


### PR DESCRIPTION
This should make builds _never_ succeed in the presence of an error, even the ones that we don't know how to parse yet.

This is better IMO because now we're not going to be a step behind changes in error output in bsb.